### PR TITLE
Add configurable `simple` option for child loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The `prefix` and `suffix` for each component is also customizable:
 var logger = require('debugnyan')('foo', {}, { suffix: 'module' });
 ```
 
+When creating a _child_ logger you may also override the default `simple` behavior:
+
+```js
+var logger = require('debugnyan')('foo:bar', {}, { simple: false });
+```
+
 ## Tests
 
 ```

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "should": "^11.1.0"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "nyc": {
     "include": [

--- a/src/index.js
+++ b/src/index.js
@@ -22,14 +22,13 @@ const level = bunyan.FATAL + 1;
  * Export `debugnyan`.
  */
 
-export default function debugnyan(name, options, config) {
+export default function debugnyan(name, options, {
+  prefix = 'sub',
+  simple = true,
+  suffix = 'component'
+} = {}) {
   const components = name.split(':');
   const [root] = components;
-
-  config = Object.assign({
-    prefix: 'sub',
-    suffix: 'component'
-  }, config);
 
   if (!loggers[root]) {
     loggers[root] = bunyan.createLogger(Object.assign({}, options, { level, name: root }));
@@ -49,11 +48,11 @@ export default function debugnyan(name, options, config) {
     }
 
     options = Object.assign({}, options, {
-      [`${config.prefix.repeat(i - 1)}${config.suffix}`]: current,
+      [`${prefix.repeat(i - 1)}${suffix}`]: current,
       level
     });
 
-    child = next.child(options, true);
+    child = next.child(options, simple);
 
     loggers[childName] = child;
   }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -66,6 +66,12 @@ describe('debugnyan', () => {
       logger.fields.component.should.equal('bar');
     });
 
+    it('should accept the `simple` option', () => {
+      const logger = debugnyan('foo:biz', {}, { simple: false });
+
+      logger.should.not.have.property('_isSimpleChild');
+    });
+
     it('should be on the debug level if `DEBUG` matches logger name', () => {
       debug.enable('foo:bar');
 


### PR DESCRIPTION
This PR adds a configurable `simple` option in order to allow creating child loggers that are not "simple" (as per bunyan's definition).

This is useful for creating child loggers with their own serializers, for example.